### PR TITLE
Fixed NoMethodError exception in memory calculation under Ubuntu

### DIFF
--- a/lib/chef/knife/kvm_vm_create.rb
+++ b/lib/chef/knife/kvm_vm_create.rb
@@ -339,7 +339,7 @@ class Chef
         vm.start
         
         puts "#{ui.color("VM Name", :cyan)}: #{vm.name}"
-        puts "#{ui.color("VM Memory", :cyan)}: #{vm.memory_size.to_i.kilobytes.to.megabytes.round} MB"
+        puts "#{ui.color("VM Memory", :cyan)}: #{vm.memory_size/1024} MB"
 
         return if config[:skip_bootstrap]
 

--- a/lib/chef/knife/kvm_vm_list.rb
+++ b/lib/chef/knife/kvm_vm_list.rb
@@ -31,7 +31,7 @@ class Chef
         vm_table = table do |t|
           t.headings = %w{NAME STATE MAX_MEM CPUS OS_TYPE ARCH}
           connection.servers.each do |vm|
-            t << [vm.name, vm.state, "#{vm.memory_size.to_i.kilobytes.to.megabytes.round} MB", vm.cpus, vm.os_type, vm.arch]
+            t << [vm.name, vm.state, "#{vm.memory_size/1024} MB", vm.cpus, vm.os_type, vm.arch]
           end
         end
         puts vm_table


### PR DESCRIPTION
I recently setup knife-kvm on multiple Ubuntu 12.04 hosts using the distro version of ruby 1.9.1 and 1.9.3 along with matching gems version.  All hosts gave me the following errors when creating and listing vms.

/var/lib/gems/1.9.1/gems/knife-kvm-0.1.2/lib/chef/knife/kvm_vm_create.rb:185:in `run': undefined method`kilobytes' for 524288:Fixnum (NoMethodError)

/var/lib/gems/1.9.1/gems/knife-kvm-0.1.2/lib/chef/knife/kvm_vm_list.rb:34:in `block (2 levels) in run': undefined method`kilobytes' for 1048576:Fixnum (NoMethodError)

The following change fixes this problem.
